### PR TITLE
Added option for enabling querying over TCP instead of UDP and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dns_query = Nslookup()
 # Alternatively, the Nslookup constructor supports optional
 # arguments for setting custom dns servers (defaults to system DNS),
 # verbosity (default: True) and using TCP instead of UDP (default: False)
-dns_query = Nslookup(dns_servers=["1.1.1.1"], verbose=False, tcp=True)
+dns_query = Nslookup(dns_servers=["1.1.1.1"], verbose=False, tcp=False)
 
 ips_record = dns_query.dns_lookup(domain)
 print(ips_record.response_full, ips_record.answer)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ from nslookup import Nslookup
 
 domain = "example.com"
 
-# set optional Cloudflare public DNS server
-dns_query = Nslookup(dns_servers=["1.1.1.1"])
+# Initialize Nslookup
+dns_query = Nslookup()
+# Alternatively, the Nslookup constructor supports optional
+# arguments for setting custom dns servers (defaults to system DNS),
+# verbosity (default: True) and using TCP instead of UDP (default: False)
+dns_query = Nslookup(dns_servers=["1.1.1.1"], verbose=False, tcp=True)
 
 ips_record = dns_query.dns_lookup(domain)
 print(ips_record.response_full, ips_record.answer)

--- a/nslookup/nslookup.py
+++ b/nslookup/nslookup.py
@@ -16,9 +16,10 @@ class DNSresponse:
 
 class Nslookup:
     """Object for initializing DNS resolver, with optional specific DNS servers"""
-    def __init__(self, dns_servers=[], verbose=True):
+    def __init__(self, dns_servers=[], verbose=True, tcp=False):
         self.dns_resolver = dns.resolver.Resolver()
         self.verbose = verbose
+        self.tcp = tcp
         if dns_servers:
             self.dns_resolver.nameservers = dns_servers
 
@@ -28,7 +29,7 @@ class Nslookup:
         # set DNS server for lookup
         try:
             # get the dns resolutions for this domain
-            answer = self.dns_resolver.query(domain, record_type)
+            answer = self.dns_resolver.query(domain, record_type, tcp=self.tcp)
             return answer
         except dns.resolver.NXDOMAIN:
             # the domain does not exist so dns resolutions remain empty


### PR DESCRIPTION
Hi!

I am using another project which is using this library as a dependency. In my case, I want to be able to do lookups via proxychains4 over a socks4 proxy. Because socks4 doesn't support UDP-proxying, the DNS request has to be sent using TCP.

I noticed that the underlying project dnspython supports the `tcp` flag in the `query()` function, so I've created a pull request to make it possible to pass `tcp=True` to the `Nslookup` function. I've set it default to `False` as that is consistent with dnspython and usually how other programs work as well.

Let me know if you have any issues with this PR!