### PR TITLE
Avoid reading system resolver config when dns_servers provided

### DIFF
--- a/nslookup/nslookup.py
+++ b/nslookup/nslookup.py
@@ -21,7 +21,7 @@ class DNSresponse:
 class Nslookup:
     """Object for initializing DNS resolver, with optional specific DNS servers"""
     def __init__(self, dns_servers=[], verbose=True, tcp=False):
-        self.dns_resolver = dns.resolver.Resolver()
+        self.dns_resolver = dns.resolver.Resolver(configure=not bool(dns_servers))
         self.verbose = verbose
 
         if tcp:


### PR DESCRIPTION
Now `Nslookup.__init__()` always creates `dns.resolver.Resolver()` and only after overrides nameservers if `dns_servers` is passed. Therefore, even with an explicit `Nslookup(dns_servers=[...])` , it still attempts to read the system resolver config such as `/etc/resolv.conf `.

Tested manually

```python
from concurrent.futures import ThreadPoolExecutor, as_completed
from nslookup import Nslookup

ips = ["8.8.8.8", "1.1.1.1"] * 2500

def check(ip):
    try:
        r = Nslookup(dns_servers=[ip], verbose=False).dns_lookup("google.com")
        return "ok" if r.answer else "empty"
    except Exception as e:
        return f"{type(e).__name__}: {e}"

counts = {}
with ThreadPoolExecutor(max_workers=50) as executor:
    futures = [executor.submit(check, ip) for ip in ips]
    for future in as_completed(futures):
        result = future.result()
        counts[result] = counts.get(result, 0) + 1

print(counts)
```

Before patch:
`{'ok': 4109, 'empty': 27, 'NoResolverConfiguration: cannot open /etc/resolv.conf': 864}`
After:
`{'ok': 4957, 'empty': 43}`